### PR TITLE
Return article details in search

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -8,3 +8,10 @@ class ArticleOut(BaseModel):
     id: str
     title: str
     content: str
+
+
+class ArticleSearchHit(BaseModel):
+    id: str
+    title: str
+    content: str
+    score: float


### PR DESCRIPTION
## Summary
- expose ArticleSearchHit schema for search results
- look up articles by IDs from Qdrant and return content with scores
- update /articles/search endpoint to return detailed hits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890e585c8588332b598f9799e2c0811