### PR TITLE
Add Streamlit frontend and article management features

### DIFF
--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+requests
+python-dotenv

--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -1,0 +1,264 @@
+import os
+import json
+import requests
+import streamlit as st
+from dotenv import load_dotenv
+
+load_dotenv()
+
+API_BASE = os.getenv("WIKI_API_BASE", "http://localhost:8000")
+YANDEX_TOKEN = os.getenv("YANDEX_OAUTH_TOKEN")
+YANDEX_FOLDER_ID = os.getenv("YANDEX_FOLDER_ID")
+
+st.set_page_config(page_title="Wiki GPT – Frontend", layout="wide")
+
+
+# ---------------------------
+# Helpers
+# ---------------------------
+def api_post(path: str, payload: dict):
+    url = f"{API_BASE}{path}"
+    r = requests.post(url, json=payload, timeout=60)
+    if r.status_code >= 400:
+        raise RuntimeError(f"POST {path} failed: {r.status_code} {r.text}")
+    return r.json()
+
+def api_put(path: str, payload: dict):
+    url = f"{API_BASE}{path}"
+    r = requests.put(url, json=payload, timeout=60)
+    if r.status_code >= 400:
+        raise RuntimeError(f"PUT {path} failed: {r.status_code} {r.text}")
+    return r.json()
+
+def api_get(path: str):
+    url = f"{API_BASE}{path}"
+    r = requests.get(url, timeout=60)
+    if r.status_code >= 400:
+        raise RuntimeError(f"GET {path} failed: {r.status_code} {r.text}")
+    return r.json()
+
+def api_delete(path: str):
+    url = f"{API_BASE}{path}"
+    r = requests.delete(url, timeout=60)
+    if r.status_code >= 400:
+        raise RuntimeError(f"DELETE {path} failed: {r.status_code} {r.text}")
+    return r.json()
+
+def search_articles(query: str, tags=None):
+    payload = {"q": query}
+    if tags:
+        payload["tags"] = tags
+    return api_post("/articles/search/", payload)
+
+def create_article(title: str, content: str, tags):
+    return api_post("/articles/", {"title": title, "content": content, "tags": tags})
+
+def update_article(article_id: str, title: str, content: str, tags):
+    return api_put(f"/articles/{article_id}", {"title": title, "content": content, "tags": tags})
+
+def get_article(article_id: str):
+    return api_get(f"/articles/{article_id}")
+
+def delete_article(article_id: str):
+    return api_delete(f"/articles/{article_id}")
+
+def get_history(article_id: str):
+    return api_get(f"/articles/{article_id}/history")
+
+def suggest_related(title: str, content: str, exclude_id: str | None = None, top_k: int = 5):
+    results = search_articles(f"{title}\n{content}")
+    unique = []
+    for hit in results:
+        if exclude_id and hit["id"] == exclude_id:
+            continue
+        unique.append(hit)
+    return unique[:top_k]
+
+def llm_recommendations(title: str, content: str) -> str:
+    if not (YANDEX_TOKEN and YANDEX_FOLDER_ID):
+        return "LLM выключен: не заданы YANDEX_OAUTH_TOKEN / YANDEX_FOLDER_ID."
+
+    url = "https://llm.api.cloud.yandex.net/foundationModels/v1/completion"
+    headers = {
+        "Authorization": f"Bearer {YANDEX_TOKEN}",
+        "Content-Type": "application/json",
+    }
+
+    prompt = (
+        "Ты – редактор и техписатель. Дай практичные рекомендации по улучшению статьи: "
+        "структура, ясность, недостающие разделы, теги. Пиши кратко и по пунктам.\n\n"
+        f"Заголовок: {title}\n\n"
+        f"Текст статьи:\n{content}\n\n"
+        "Ответ формируй в формате маркдаун-списка."
+    )
+
+    payload = {
+        "modelUri": f"gpt://{YANDEX_FOLDER_ID}/yandexgpt-lite/latest",
+        "completionOptions": {"stream": False, "temperature": 0.2, "maxTokens": 400},
+        "messages": [
+            {"role": "system", "text": "Ты помогаешь улучшать статьи в базе знаний."},
+            {"role": "user", "text": prompt},
+        ],
+    }
+
+    r = requests.post(url, headers=headers, json=payload, timeout=90)
+    if r.status_code != 200:
+        return f"Ошибка LLM: {r.status_code} {r.text}"
+
+    data = r.json()
+    alternatives = data.get("result", {}).get("alternatives") or data.get("alternatives")
+    if alternatives:
+        text = alternatives[0].get("message", {}).get("text", "").strip()
+        if text:
+            return text
+    return "Не удалось распарсить ответ LLM:\n\n" + json.dumps(data, ensure_ascii=False, indent=2)
+
+
+# ---------------------------
+# UI
+# ---------------------------
+st.sidebar.title("Wiki GPT")
+page = st.sidebar.radio(
+    "Навигация",
+    ["Создать статью", "Редактировать статью", "Поиск", "Статья по ID", "Диагностика"],
+)
+
+st.sidebar.markdown("---")
+st.sidebar.caption(f"Backend: {API_BASE}")
+
+# --- Создать ---
+if page == "Создать статью":
+    st.header("Создать статью")
+    with st.form("create_form"):
+        title = st.text_input("Заголовок", "")
+        tags = st.text_input("Теги (через запятую)", "")
+        content = st.text_area("Текст статьи", height=300, placeholder="Содержимое в Markdown/тексте")
+        submitted = st.form_submit_button("Сохранить статью")
+    if submitted:
+        if not title.strip() or not content.strip():
+            st.error("Заполните заголовок и текст.")
+        else:
+            try:
+                tag_list = [t.strip() for t in tags.split(",") if t.strip()]
+                res = create_article(title.strip(), content.strip(), tag_list)
+                st.success(f"Создано! ID: {res['id']}")
+                with st.expander("Похожие статьи сразу после сохранения"):
+                    related = suggest_related(title, content, exclude_id=res['id'], top_k=5)
+                    for hit in related:
+                        st.write(f"**{hit['title']}** · score={hit.get('score'):.3f}")
+                        st.caption(f"{hit['id']} · теги: {', '.join(hit.get('tags', []))}")
+                        st.write(hit["content"])
+                        st.markdown("---")
+            except Exception as e:
+                st.error(str(e))
+
+# --- Редактировать ---
+elif page == "Редактировать статью":
+    st.header("Редактировать статью")
+    st.caption("Укажи ID статьи (можно взять из результата создания/поиска).")
+    article_id = st.text_input("Article ID", "")
+    title = st.text_input("Новый заголовок", "")
+    tags = st.text_input("Новые теги (через запятую)", "")
+    content = st.text_area("Новый текст статьи", height=300)
+
+    col1, col2 = st.columns([1, 1])
+    with col1:
+        if st.button("Сохранить изменения"):
+            if not article_id.strip():
+                st.error("Укажи ID статьи.")
+            elif not title.strip() or not content.strip():
+                st.error("Заполни заголовок и текст.")
+            else:
+                try:
+                    tag_list = [t.strip() for t in tags.split(",") if t.strip()]
+                    res = update_article(article_id.strip(), title.strip(), content.strip(), tag_list)
+                    st.success(f"Обновлено: {res['id']}")
+                except Exception as e:
+                    st.error(str(e))
+    with col2:
+        if st.button("Рекомендации к статье (LLM)"):
+            if not title.strip() and not content.strip():
+                st.warning("Сначала заполни заголовок/текст.")
+            else:
+                with st.spinner("Генерирую рекомендации..."):
+                    tips = llm_recommendations(title.strip(), content.strip())
+                st.markdown("### Рекомендации")
+                st.markdown(tips)
+
+    st.markdown("---")
+    if st.button("Найти похожие статьи"):
+        if not title.strip() and not content.strip():
+            st.warning("Сначала заполни заголовок/текст — по ним ищем похожие.")
+        else:
+            related = suggest_related(title, content, exclude_id=article_id.strip(), top_k=10)
+            st.subheader("Похожие статьи")
+            for hit in related:
+                st.write(f"**{hit['title']}** · score={hit.get('score'):.3f}")
+                st.caption(f"{hit['id']} · теги: {', '.join(hit.get('tags', []))}")
+                st.write(hit["content"])
+                st.markdown("---")
+
+# --- Поиск ---
+elif page == "Поиск":
+    st.header("Поиск по базе знаний")
+    q = st.text_input("Запрос", placeholder="например: YandexGPT эмбеддинги")
+    tags_filter = st.text_input("Фильтр по тегам (через запятую)", "")
+    topk = st.slider("Сколько результатов показать", 1, 20, 5)
+    if st.button("Искать") and q.strip():
+        try:
+            tag_list = [t.strip() for t in tags_filter.split(",") if t.strip()]
+            results = search_articles(q.strip(), tag_list)[:topk]
+            st.subheader("Результаты")
+            for hit in results:
+                st.write(f"**{hit['title']}** · score={hit.get('score'):.3f}")
+                st.caption(f"{hit['id']} · теги: {', '.join(hit.get('tags', []))}")
+                st.write(hit["content"])
+                st.markdown("---")
+        except Exception as e:
+            st.error(str(e))
+
+# --- Статья по ID ---
+elif page == "Статья по ID":
+    st.header("Статья по ID")
+    with st.form("view_form"):
+        view_id = st.text_input("Article ID", value=st.session_state.get("view_id", ""))
+        submitted = st.form_submit_button("Загрузить")
+    if submitted and view_id.strip():
+        try:
+            st.session_state.view_id = view_id.strip()
+            st.session_state.view_article = get_article(view_id.strip())
+            st.session_state.view_history = get_history(view_id.strip())
+        except Exception as e:
+            st.error(str(e))
+    article = st.session_state.get("view_article")
+    if article:
+        tabs = st.tabs(["Статья", "История"])
+        with tabs[0]:
+            st.subheader(article["title"])
+            st.write(article["content"])
+            st.caption(f"Теги: {', '.join(article.get('tags', []))}")
+            if st.button("Удалить статью"):
+                try:
+                    delete_article(article["id"])
+                    st.success("Удалено")
+                    st.session_state.view_article = None
+                    st.session_state.view_history = None
+                except Exception as e:
+                    st.error(str(e))
+        with tabs[1]:
+            history = st.session_state.get("view_history", [])
+            if history:
+                st.table(history)
+            else:
+                st.info("История пуста")
+
+# --- Диагностика ---
+else:
+    st.header("Диагностика")
+    st.write("Проверка окружения:")
+    st.json({
+        "API_BASE": API_BASE,
+        "YANDEX_OAUTH_TOKEN": bool(YANDEX_TOKEN),
+        "YANDEX_FOLDER_ID": YANDEX_FOLDER_ID or "",
+    })
+    st.caption("Если LLM выключен — рекомендации и рерэнк будут недоступны.")

--- a/main.py
+++ b/main.py
@@ -3,10 +3,23 @@ from uuid import UUID
 from typing import List
 from sqlalchemy.orm import Session
 from db import SessionLocal, engine
-from models import Article, Base
-from qdrant_utils import (embed_text, ensure_collection, insert_vector,
-                          search_vector)
-from schemas import ArticleCreate, ArticleOut, ArticleSearchHit, ArticleUpdate
+from models import Article, ArticleVersion, Base
+from qdrant_utils import (
+    embed_text,
+    ensure_collection,
+    insert_vector,
+    search_vector,
+    delete_vector,
+    rerank_with_llm,
+)
+from schemas import (
+    ArticleCreate,
+    ArticleOut,
+    ArticleSearchHit,
+    ArticleUpdate,
+    ArticleVersionOut,
+    ArticleSearchQuery,
+)
 
 Base.metadata.create_all(bind=engine)
 ensure_collection()
@@ -24,13 +37,19 @@ def get_db():
 
 @app.post("/articles/", response_model=ArticleOut)
 def create_article(article: ArticleCreate, db: Session = Depends(get_db)):
-    db_article = Article(title=article.title, content=article.content)
+    db_article = Article(
+        title=article.title,
+        content=article.content,
+        tags=",".join(article.tags),
+    )
     db.add(db_article)
     db.commit()
     db.refresh(db_article)
 
     embedding = embed_text(f"{article.title}\n{article.content}")
     insert_vector(db_article.id, embedding)
+
+    save_version(db_article, db)
 
     return db_article
 
@@ -43,16 +62,78 @@ def update_article(article_id: UUID, article: ArticleUpdate, db: Session = Depen
 
     db_article.title = article.title
     db_article.content = article.content
+    db_article.tags = ",".join(article.tags)
     db.commit()
     db.refresh(db_article)
 
     embedding = embed_text(f"{article.title}\n{article.content}")
     insert_vector(db_article.id, embedding)
 
+    save_version(db_article, db)
+
     return db_article
 
 
+@app.get("/articles/{article_id}", response_model=ArticleOut)
+def get_article(article_id: UUID, db: Session = Depends(get_db)):
+    db_article = db.query(Article).filter(Article.id == str(article_id)).first()
+    if db_article is None:
+        raise HTTPException(status_code=404, detail="Article not found")
+    return db_article
+
+
+@app.delete("/articles/{article_id}")
+def delete_article(article_id: UUID, db: Session = Depends(get_db)):
+    db_article = db.query(Article).filter(Article.id == str(article_id)).first()
+    if db_article is None:
+        raise HTTPException(status_code=404, detail="Article not found")
+    db.delete(db_article)
+    db.query(ArticleVersion).filter(ArticleVersion.article_id == str(article_id)).delete()
+    db.commit()
+    delete_vector(str(article_id))
+    return {"status": "deleted"}
+
+
+@app.get("/articles/{article_id}/history", response_model=List[ArticleVersionOut])
+def article_history(article_id: UUID, db: Session = Depends(get_db)):
+    versions = (
+        db.query(ArticleVersion)
+        .filter(ArticleVersion.article_id == str(article_id))
+        .order_by(ArticleVersion.created_at.desc())
+        .all()
+    )
+    return [
+        ArticleVersionOut(
+            id=v.id,
+            article_id=v.article_id,
+            title=v.title,
+            content=v.content,
+            tags=v.tags.split(",") if v.tags else [],
+            created_at=v.created_at.isoformat(),
+        )
+        for v in versions
+    ]
+
+
 @app.post("/articles/search/", response_model=List[ArticleSearchHit])
-def search_articles(q: str = Body(..., embed=True), db: Session = Depends(get_db)):
-    query_embedding = embed_text(q)
-    return search_vector(query_embedding, db=db)
+def search_articles(
+    query: ArticleSearchQuery = Body(...), db: Session = Depends(get_db)
+):
+    query_embedding = embed_text(query.q)
+    hits = search_vector(query_embedding, db=db)
+    if query.tags:
+        required = set(query.tags)
+        hits = [h for h in hits if required.issubset(set(h.tags))]
+    hits = rerank_with_llm(query.q, hits)
+    return hits
+
+
+def save_version(article: Article, db: Session):
+    version = ArticleVersion(
+        article_id=article.id,
+        title=article.title,
+        content=article.content,
+        tags=article.tags,
+    )
+    db.add(version)
+    db.commit()

--- a/models.py
+++ b/models.py
@@ -10,4 +10,17 @@ class Article(Base):
     id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     title = Column(String, nullable=False)
     content = Column(Text, nullable=False)
+    tags = Column(String, default="")
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class ArticleVersion(Base):
+    """Historical version of an article."""
+
+    __tablename__ = "article_versions"
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    article_id = Column(String, index=True)
+    title = Column(String, nullable=False)
+    content = Column(Text, nullable=False)
+    tags = Column(String, default="")
     created_at = Column(DateTime, default=datetime.utcnow)

--- a/qdrant_utils.py
+++ b/qdrant_utils.py
@@ -4,7 +4,7 @@ import requests
 from dotenv import load_dotenv
 from qdrant_client import QdrantClient
 from qdrant_client.http.models import Distance, PointStruct, VectorParams
-from typing import List
+from typing import List, Dict
 from sqlalchemy.orm import Session
 from models import Article
 from schemas import ArticleSearchHit
@@ -52,6 +52,10 @@ def insert_vector(article_id: str, embedding: list[float]):
     )
 
 
+def delete_vector(article_id: str):
+    client.delete(collection_name=COLLECTION_NAME, points_selector={"points": [article_id]})
+
+
 def search_vector(vector: List[float], db: Session, limit: int = 5) -> List[ArticleSearchHit]:
     hits = client.search(
         collection_name=COLLECTION_NAME,
@@ -69,10 +73,53 @@ def search_vector(vector: List[float], db: Session, limit: int = 5) -> List[Arti
             id=str(a.id),
             title=a.title,
             content=a.content,
-            score=scores[str(a.id)]
+            score=scores[str(a.id)],
+            tags=a.tags.split(",") if a.tags else [],
         )
         for a in articles
     ]
+
+
+def rerank_with_llm(query: str, hits: List[ArticleSearchHit]) -> List[ArticleSearchHit]:
+    """Re-rank search hits using YandexGPT if credentials are set."""
+    if not (YANDEX_OAUTH_TOKEN and YANDEX_FOLDER_ID) or not hits:
+        return hits
+
+    url = "https://llm.api.cloud.yandex.net/foundationModels/v1/completion"
+    headers = {
+        "Authorization": f"Bearer {YANDEX_OAUTH_TOKEN}",
+        "Content-Type": "application/json",
+    }
+
+    parts = []
+    for idx, hit in enumerate(hits, 1):
+        parts.append(f"{idx}. id={hit.id} title={hit.title}\n{hit.content}")
+    prompt = (
+        "Ты – поисковый ранжировщик. По запросу пользователя упорядочи статьи по релевантности."
+        " Верни JSON-массив ID в порядке убывания релевантности.\n"
+        f"Запрос: {query}\n\n" + "\n\n".join(parts)
+    )
+
+    payload = {
+        "modelUri": f"gpt://{YANDEX_FOLDER_ID}/yandexgpt-lite/latest",
+        "completionOptions": {"stream": False, "temperature": 0.0, "maxTokens": 200},
+        "messages": [{"role": "user", "text": prompt}],
+    }
+
+    try:
+        r = requests.post(url, headers=headers, json=payload, timeout=60)
+        if r.status_code != 200:
+            return hits
+        data = r.json()
+        alternatives = data.get("result", {}).get("alternatives") or data.get("alternatives")
+        text = alternatives[0]["message"].get("text", "") if alternatives else ""
+        order = [s.strip() for s in text.split() if s.strip() in {h.id for h in hits}]
+        if order:
+            id_to_hit: Dict[str, ArticleSearchHit] = {h.id: h for h in hits}
+            return [id_to_hit[i] for i in order if i in id_to_hit]
+    except Exception:
+        return hits
+    return hits
 
 def embed_text(text: str) -> list[float]:
     headers = {

--- a/schemas.py
+++ b/schemas.py
@@ -1,19 +1,23 @@
 from pydantic import BaseModel
 from uuid import UUID
+from typing import List, Optional
 
 class ArticleCreate(BaseModel):
     title: str
     content: str
+    tags: List[str] = []
 
 
 class ArticleUpdate(BaseModel):
     title: str
     content: str
+    tags: List[str] = []
 
 class ArticleOut(BaseModel):
     id: str
     title: str
     content: str
+    tags: List[str] = []
 
 
 class ArticleSearchHit(BaseModel):
@@ -21,3 +25,18 @@ class ArticleSearchHit(BaseModel):
     title: str
     content: str
     score: float
+    tags: List[str] = []
+
+
+class ArticleVersionOut(BaseModel):
+    id: str
+    article_id: str
+    title: str
+    content: str
+    tags: List[str] = []
+    created_at: str
+
+
+class ArticleSearchQuery(BaseModel):
+    q: str
+    tags: Optional[List[str]] = None


### PR DESCRIPTION
## Summary
- support tags and article version history in backend
- add endpoints for view, delete and history with LLM rerank in search
- introduce Streamlit frontend with creation, editing, search and article view

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891080e3f30833282c47d2d08c8cf0f