### PR TITLE
Handle missing Streamlit secrets

### DIFF
--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -6,15 +6,22 @@ import logging
 import requests
 import streamlit as st
 from dotenv import load_dotenv
+from streamlit.errors import StreamlitSecretNotFoundError
 
 load_dotenv()
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 def _env_or_secret(key: str) -> str | None:
-    value = (os.getenv(key) or st.secrets.get(key, "")).strip()
-    return value or None
+    env_val = os.getenv(key)
+    if env_val:
+        return env_val.strip()
+    try:
+        return st.secrets[key].strip()
+    except (KeyError, StreamlitSecretNotFoundError):
+        return None
 
 API_BASE = os.getenv("WIKI_API_BASE", "http://localhost:8000")
 YANDEX_TOKEN = _env_or_secret("YANDEX_OAUTH_TOKEN")


### PR DESCRIPTION
## Summary
- prevent frontend crash when Streamlit secrets are absent by safely reading environment variables or secrets

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68921b73ad9483329f06f44cdfa84fe3