### PR TITLE
Handle missing session state for LLM timer

### DIFF
--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -177,8 +177,8 @@ if page == "Создать статью":
             st.session_state.llm_timer.cancel()
 
         def run():
-            title = st.session_state.create_title.strip()
-            content = st.session_state.create_content.strip()
+            title = st.session_state.get("create_title", "").strip()
+            content = st.session_state.get("create_content", "").strip()
             if not title and not content:
                 st.session_state.llm_tips = ""
             else:


### PR DESCRIPTION
## Summary
- prevent background LLM thread from crashing when create fields are missing

## Testing
- `python -m py_compile frontend/streamlit_app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68921eb01c3c8332aa3fc1b14c45efad