### PR TITLE
fix: escape braces in markdown toolbar

### DIFF
--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -195,7 +195,7 @@ def markdown_editor(label: str, key: str, *, height: int = 300, placeholder: str
             textarea.selectionStart = textarea.selectionEnd = pos;
             textarea.dispatchEvent(new Event('input', {{ bubbles: true }}));
         }}
-        window.addEventListener('load', () => {
+        window.addEventListener('load', () => {{
             document.getElementById('bold').addEventListener('click', () => surround('**','**'));
             document.getElementById('italic').addEventListener('click', () => surround('*','*'));
             document.getElementById('h1').addEventListener('click', () => surround('# ',''));
@@ -203,7 +203,7 @@ def markdown_editor(label: str, key: str, *, height: int = 300, placeholder: str
             document.getElementById('link').addEventListener('click', () => surround('[','](url)'));
             document.getElementById('code').addEventListener('click', () => surround('\n```\n','\n```\n'));
             document.getElementById('table').addEventListener('click', insertTable);
-        });
+        }});
 
         </script>
         """,


### PR DESCRIPTION
## Summary
- fix Streamlit f-string parsing error by escaping braces in JavaScript event handler

## Testing
- `pytest`
- `python -m py_compile frontend/streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68924005b1f483329130981615a410d2