### PR TITLE
Add user registration with team isolation

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -8,6 +8,17 @@ import uuid
 Base = declarative_base()
 
 
+class Team(Base):
+    __tablename__ = "teams"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name = Column(String, nullable=False, unique=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    users = relationship("User", back_populates="team")
+    articles = relationship("Article", back_populates="team")
+
+
 class User(Base):
     __tablename__ = "users"
 
@@ -16,7 +27,9 @@ class User(Base):
     password_hash = Column(String, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)
     is_active = Column(Boolean, default=True)
+    team_id = Column(UUID(as_uuid=True), ForeignKey("teams.id"))
 
+    team = relationship("Team", back_populates="users")
     roles = relationship("Role", secondary="user_roles", back_populates="users")
 
 
@@ -45,6 +58,7 @@ class ArticleGroup(Base):
 
     articles = relationship("Article", back_populates="group")
 
+
 class Article(Base):
     __tablename__ = "articles"
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -53,9 +67,11 @@ class Article(Base):
     tags = Column(String, default="")
     created_at = Column(DateTime, default=datetime.utcnow)
     group_id = Column(UUID(as_uuid=True), ForeignKey("article_groups.id"), nullable=True)
+    team_id = Column(UUID(as_uuid=True), ForeignKey("teams.id"), nullable=True)
     is_deleted = Column(Boolean, default=False)
 
     group = relationship("ArticleGroup", back_populates="articles")
+    team = relationship("Team", back_populates="articles")
 
 
 class ArticleVersion(Base):

--- a/backend/qdrant_utils.py
+++ b/backend/qdrant_utils.py
@@ -70,12 +70,12 @@ def delete_vector(article_id: str):
     client.delete(collection_name=COLLECTION_NAME, points_selector=[article_id])
 
 
-def search_vector(vector: List[float], db: Session, limit: int = 5) -> List[ArticleSearchHit]:
+def search_vector(vector: List[float], db: Session, team_id, limit: int = 5) -> List[ArticleSearchHit]:
     hits = client.search(
         collection_name=COLLECTION_NAME,
         query_vector=vector,
         limit=limit,
-        with_payload=True
+        with_payload=True,
     )
 
     ids = [UUID_cls(str(hit.id)) for hit in hits]
@@ -83,7 +83,11 @@ def search_vector(vector: List[float], db: Session, limit: int = 5) -> List[Arti
 
     articles = (
         db.query(Article)
-        .filter(Article.id.in_(ids), Article.is_deleted == False)
+        .filter(
+            Article.id.in_(ids),
+            Article.is_deleted == False,
+            Article.team_id == team_id,
+        )
         .all()
     )
     return [

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, constr
 from uuid import UUID
 from typing import List, Optional
 
@@ -63,7 +63,7 @@ class ArticleGroupOut(BaseModel):
 
 class UserCreate(BaseModel):
     email: EmailStr
-    password: str
+    password: constr(min_length=8)
 
 
 class LoginRequest(BaseModel):
@@ -89,3 +89,11 @@ class UserOut(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class RegisterResponse(BaseModel):
+    user_id: UUID
+    email: EmailStr
+    team_id: UUID
+    access_token: str
+    refresh_token: str

--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -231,20 +231,36 @@ def markdown_editor(label: str, key: str, *, height: int = 300, placeholder: str
 # Auth & UI
 # ---------------------------
 if "access_token" not in st.session_state:
-    st.header("Вход")
-    with st.form("login_form"):
-        email = st.text_input("Email")
-        password = st.text_input("Пароль", type="password")
-        submitted = st.form_submit_button("Войти")
-    if submitted:
-        try:
-            data = api_post("/auth/login", {"email": email, "password": password})
-            st.session_state["access_token"] = data["access_token"]
-            st.session_state["refresh_token"] = data["refresh_token"]
-            st.session_state["user"] = api_get("/auth/me")
-            st.experimental_rerun()
-        except Exception as e:
-            st.error(str(e))
+    tab_login, tab_register = st.tabs(["Вход", "Регистрация"])
+    with tab_login:
+        with st.form("login_form"):
+            email = st.text_input("Email")
+            password = st.text_input("Пароль", type="password")
+            submitted = st.form_submit_button("Войти")
+        if submitted:
+            try:
+                data = api_post("/auth/login", {"email": email, "password": password})
+                st.session_state["access_token"] = data["access_token"]
+                st.session_state["refresh_token"] = data["refresh_token"]
+                st.session_state["user"] = api_get("/auth/me")
+                st.experimental_rerun()
+            except Exception as e:
+                st.error(str(e))
+
+    with tab_register:
+        with st.form("register_form"):
+            r_email = st.text_input("Email", key="reg_email")
+            r_password = st.text_input("Пароль", type="password", key="reg_password")
+            r_submitted = st.form_submit_button("Зарегистрироваться")
+        if r_submitted:
+            try:
+                data = api_post("/auth/register", {"email": r_email, "password": r_password})
+                st.session_state["access_token"] = data["access_token"]
+                st.session_state["refresh_token"] = data["refresh_token"]
+                st.session_state["user"] = api_get("/auth/me")
+                st.experimental_rerun()
+            except Exception as e:
+                st.error(str(e))
     st.stop()
 
 if "user" not in st.session_state:

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import types
+import pathlib
+import pytest
+from fastapi.testclient import TestClient
+
+# Configure environment and stub external dependencies before importing app
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+base_dir = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(base_dir))
+sys.path.append(str(base_dir / "backend"))
+
+fake_qdrant = types.ModuleType("qdrant_utils")
+fake_qdrant.embed_text = lambda text: [0.0] * 256
+fake_qdrant.ensure_collection = lambda: None
+fake_qdrant.insert_vector = lambda *a, **kw: None
+fake_qdrant.delete_vector = lambda *a, **kw: None
+fake_qdrant.search_vector = lambda vector, db, team_id, limit=5: []
+fake_qdrant.rerank_with_llm = lambda *a, **kw: []
+sys.modules["qdrant_utils"] = fake_qdrant
+
+from backend.main import app, Base, engine
+from backend.auth import init_roles
+
+# Reset database and roles
+Base.metadata.drop_all(bind=engine)
+Base.metadata.create_all(bind=engine)
+init_roles()
+
+client = TestClient(app)
+
+
+def auth_headers(token: str):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def register(email: str):
+    r = client.post("/auth/register", json={"email": email, "password": "password123"})
+    assert r.status_code == 200
+    return r.json()
+
+
+def test_register_and_conflict():
+    register("a@example.com")
+    r = client.post("/auth/register", json={"email": "a@example.com", "password": "password123"})
+    assert r.status_code == 409
+
+
+def test_article_isolation():
+    user_a = register("usera@example.com")
+    token_a = user_a["access_token"]
+
+    r = client.post(
+        "/articles/",
+        json={"title": "A1", "content": "content", "tags": []},
+        headers=auth_headers(token_a),
+    )
+    assert r.status_code == 200
+    article_id = r.json()["id"]
+
+    user_b = register("userb@example.com")
+    token_b = user_b["access_token"]
+
+    r = client.get("/articles/", headers=auth_headers(token_b))
+    assert r.status_code == 200
+    assert r.json() == []
+
+    r = client.get(f"/articles/{article_id}", headers=auth_headers(token_b))
+    assert r.status_code == 404


### PR DESCRIPTION
## Summary
- create teams and link users and articles to their team
- implement email registration returning JWT tokens and default roles
- add registration UI and team-aware article filtering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689259bd4f248332a8663d7f3e4eacfd