### PR TITLE
Add streamlit-ace dependency

### DIFF
--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -1,3 +1,4 @@
 streamlit
 requests
 python-dotenv
+streamlit-ace


### PR DESCRIPTION
## Summary
- include streamlit-ace in frontend requirements to provide Ace editor component

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68933923a8d08332a28e0430a6a07b0e