### PR TITLE
Forward on_change callback in markdown_editor

### DIFF
--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -164,7 +164,15 @@ def llm_recommendations(title: str, content: str) -> str:
 # ---------------------------
 # Markdown editor via streamlit-ace
 # ---------------------------
-def markdown_editor(label: str, key: str, *, height=300, placeholder=None, language="markdown"):
+def markdown_editor(
+    label: str,
+    key: str,
+    *,
+    height=300,
+    placeholder=None,
+    language="markdown",
+    on_change=None,
+):
     content = st_ace(
         placeholder=placeholder or "",
         language=language,
@@ -176,6 +184,7 @@ def markdown_editor(label: str, key: str, *, height=300, placeholder=None, langu
         show_print_margin=False,
         wrap=True,
         auto_update=True,
+        on_change=on_change,
     )
     return content or ""
 # ---------------------------


### PR DESCRIPTION
## Summary
- allow markdown_editor to accept on_change and pass to st_ace

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68933bcce9d0833283da4d295c89fddc