### PR TITLE
Handle st_ace without on_change callback

### DIFF
--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -173,6 +173,7 @@ def markdown_editor(
     language="markdown",
     on_change=None,
 ):
+    prev_content = st.session_state.get(key, "")
     content = st_ace(
         placeholder=placeholder or "",
         language=language,
@@ -184,8 +185,9 @@ def markdown_editor(
         show_print_margin=False,
         wrap=True,
         auto_update=True,
-        on_change=on_change,
     )
+    if on_change and content != prev_content:
+        on_change()
     return content or ""
 # ---------------------------
 # Auth & UI


### PR DESCRIPTION
## Summary
- adapt `markdown_editor` to streamlit-ace API change by removing unsupported `on_change` parameter
- manually trigger callbacks when editor content changes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68933dbd38848332952083c5b6c76713