### PR TITLE
Add missing streamlit-quill dependency

### DIFF
--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -1,3 +1,4 @@
 streamlit
 requests
 python-dotenv
+streamlit-quill


### PR DESCRIPTION
## Summary
- Include `streamlit-quill` in frontend requirements to resolve ModuleNotFoundError

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b25aeb8c8332ab8e3585b814350c