### PR TITLE
feat: add database readiness check

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -1,6 +1,8 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.exc import OperationalError
 import os
+import time
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -16,3 +18,14 @@ def get_db():
         yield db
     finally:
         db.close()
+
+
+def wait_for_db(max_attempts: int = 10, delay: int = 1) -> None:
+    """Attempt to connect to the database until it is ready."""
+    for _ in range(max_attempts):
+        try:
+            with engine.connect():
+                return
+        except OperationalError:
+            time.sleep(delay)
+    raise RuntimeError("Database is not ready")

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from uuid import UUID
 from typing import List
 from sqlalchemy.orm import Session
 from sqlalchemy import inspect, text
-from db import get_db, SessionLocal, engine
+from db import get_db, SessionLocal, engine, wait_for_db
 from models import Article, ArticleVersion, ArticleGroup, Base
 from auth import router as auth_router, require_roles, init_roles
 from qdrant_utils import (
@@ -25,6 +25,7 @@ from schemas import (
     ArticleGroupOut,
 )
 
+wait_for_db()
 Base.metadata.create_all(bind=engine)
 
 


### PR DESCRIPTION
## Summary
- wait for database to accept connections before starting API
- initialize tables only after DB is available

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b562dc60833280823704a5676fb8