### PR TITLE
Fix Streamlit session state conflict

### DIFF
--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -379,7 +379,7 @@ if page == "Создать статью":
             value=_state_str("create_content"),
             html=True,
             placeholder="Напишите статью...",
-            key="create_content",
+            key="create_content_editor",
         )
 
         if content is not None:


### PR DESCRIPTION
## Summary
- avoid modifying Streamlit session state key used by widget to prevent StreamlitAPIException

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689449a27224833298f9e05abc043469