### PR TITLE
feat: add hierarchical article groups

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 from fastapi import Body, Depends, FastAPI, HTTPException, APIRouter
 from uuid import UUID
-from typing import List
+from typing import List, Optional
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from sqlalchemy import inspect, text
 from db import get_db, SessionLocal, engine, wait_for_db
@@ -21,8 +22,9 @@ from schemas import (
     ArticleUpdate,
     ArticleVersionOut,
     ArticleSearchQuery,
-    ArticleGroupCreate,
+    ArticleGroupIn,
     ArticleGroupOut,
+    ArticleGroupTreeNode,
     AdminUserOut,
     RoleUpdateRequest,
     PasswordResetRequest,
@@ -58,6 +60,14 @@ def ensure_columns():
             conn.execute(
                 text("ALTER TABLE article_versions ADD COLUMN tags TEXT DEFAULT ''")
             )
+
+        group_cols = [c["name"] for c in inspector.get_columns("article_groups")]
+        if "parent_id" not in group_cols:
+            conn.execute(text("ALTER TABLE article_groups ADD COLUMN parent_id UUID"))
+        if "prompt_template" not in group_cols:
+            conn.execute(text("ALTER TABLE article_groups ADD COLUMN prompt_template TEXT"))
+        if "order" not in group_cols:
+            conn.execute(text('ALTER TABLE article_groups ADD COLUMN "order" INT'))
 
 
 ensure_columns()
@@ -129,25 +139,148 @@ def reset_user_password(
 app.include_router(admin_router)
 
 
-@app.post("/groups/", response_model=ArticleGroupOut)
+@app.post("/article-groups/", response_model=ArticleGroupOut)
 def create_group(
-    group: ArticleGroupCreate,
+    group: ArticleGroupIn,
     db: Session = Depends(get_db),
     current_user=Depends(require_roles(["admin"])),
 ):
-    db_group = ArticleGroup(name=group.name, description=group.description)
+    db_group = ArticleGroup(
+        name=group.name,
+        description=group.description,
+        parent_id=group.parent_id,
+        prompt_template=group.prompt_template,
+        order=group.order,
+    )
     db.add(db_group)
     db.commit()
     db.refresh(db_group)
     return db_group
 
 
-@app.get("/groups/", response_model=List[ArticleGroupOut])
+@app.get("/article-groups/flat", response_model=List[ArticleGroupOut])
 def list_groups(
     db: Session = Depends(get_db),
     current_user=Depends(require_roles(["reader"])),
 ):
-    return db.query(ArticleGroup).all()
+    return db.query(ArticleGroup).order_by(ArticleGroup.order).all()
+
+
+def _build_group_tree(groups, articles):
+    nodes = {
+        g.id: ArticleGroupTreeNode(
+            id=g.id,
+            name=g.name,
+            description=g.description,
+            parent_id=g.parent_id,
+            prompt_template=g.prompt_template,
+            order=g.order,
+            children=[],
+            articles=[],
+        )
+        for g in groups
+    }
+
+    for a in articles:
+        node = nodes.get(a.group_id)
+        if node:
+            node.articles.append(
+                ArticleOut(
+                    id=a.id,
+                    title=a.title,
+                    content=a.content,
+                    tags=a.tags.split(",") if a.tags else [],
+                    group_id=a.group_id,
+                )
+            )
+
+    roots: List[ArticleGroupTreeNode] = []
+    for g in groups:
+        node = nodes[g.id]
+        if g.parent_id and g.parent_id in nodes:
+            nodes[g.parent_id].children.append(node)
+        else:
+            roots.append(node)
+    return roots
+
+
+@app.get("/article-groups/tree", response_model=List[ArticleGroupTreeNode])
+def groups_tree(
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(["reader"])),
+):
+    groups = db.query(ArticleGroup).order_by(ArticleGroup.order).all()
+    articles = (
+        db.query(Article)
+        .filter(
+            Article.is_deleted == False,
+            Article.team_id == current_user.team_id,
+        )
+        .all()
+    )
+    return _build_group_tree(groups, articles)
+
+
+@app.put("/article-groups/{group_id}", response_model=ArticleGroupOut)
+def update_group(
+    group_id: UUID,
+    group: ArticleGroupIn,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(["admin"])),
+):
+    db_group = db.query(ArticleGroup).filter(ArticleGroup.id == group_id).first()
+    if not db_group:
+        raise HTTPException(status_code=404, detail="Group not found")
+    db_group.name = group.name
+    db_group.description = group.description
+    db_group.parent_id = group.parent_id
+    db_group.prompt_template = group.prompt_template
+    db_group.order = group.order
+    db.commit()
+    db.refresh(db_group)
+    return db_group
+
+
+@app.delete("/article-groups/{group_id}")
+def delete_group(
+    group_id: UUID,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(["admin"])),
+):
+    db_group = db.query(ArticleGroup).filter(ArticleGroup.id == group_id).first()
+    if not db_group:
+        raise HTTPException(status_code=404, detail="Group not found")
+    db.delete(db_group)
+    db.commit()
+    return {"status": "deleted"}
+
+
+class AssignGroupRequest(BaseModel):
+    group_id: Optional[UUID] = None
+
+
+@app.post("/articles/{article_id}/assign-group")
+def assign_group(
+    article_id: UUID,
+    req: AssignGroupRequest,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_roles(["author"])),
+):
+    article = (
+        db.query(Article)
+        .filter(
+            Article.id == article_id,
+            Article.team_id == current_user.team_id,
+            Article.is_deleted == False,
+        )
+        .first()
+    )
+    if not article:
+        raise HTTPException(status_code=404, detail="Article not found")
+    article.group_id = req.group_id
+    db.commit()
+    db.refresh(article)
+    return {"status": "ok", "group_id": article.group_id}
 
 
 @app.get("/articles/", response_model=List[ArticleOut])
@@ -342,6 +475,8 @@ def search_articles(
     if query.tags:
         required = set(query.tags)
         hits = [h for h in hits if required.issubset(set(h.tags))]
+    if query.group_id:
+        hits = [h for h in hits if h.group_id == query.group_id]
     hits = rerank_with_llm(query.q, hits)
     return hits
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Text, DateTime, ForeignKey, Boolean
+from sqlalchemy import Column, String, Text, DateTime, ForeignKey, Boolean, Integer
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
@@ -55,6 +55,11 @@ class ArticleGroup(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = Column(String, nullable=False)
     description = Column(Text, nullable=True)
+    parent_id = Column(UUID(as_uuid=True), ForeignKey("article_groups.id"), nullable=True)
+    prompt_template = Column(Text, nullable=True)
+    order = Column(Integer, nullable=True)
+
+    parent = relationship("ArticleGroup", remote_side=[id], backref="children")
 
     articles = relationship("Article", back_populates="group")
 

--- a/backend/qdrant_utils.py
+++ b/backend/qdrant_utils.py
@@ -97,6 +97,7 @@ def search_vector(vector: List[float], db: Session, team_id, limit: int = 5) -> 
             content=a.content,
             score=scores[str(a.id)],
             tags=a.tags.split(",") if a.tags else [],
+            group_id=a.group_id,
         )
         for a in articles
     ]

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -32,6 +32,7 @@ class ArticleSearchHit(BaseModel):
     content: str
     score: float
     tags: List[str] = []
+    group_id: Optional[UUID] = None
 
 
 class ArticleVersionOut(BaseModel):
@@ -46,20 +47,31 @@ class ArticleVersionOut(BaseModel):
 class ArticleSearchQuery(BaseModel):
     q: str
     tags: Optional[List[str]] = None
+    group_id: Optional[UUID] = None
 
 
-class ArticleGroupCreate(BaseModel):
+class ArticleGroupIn(BaseModel):
     name: str
     description: Optional[str] = None
+    parent_id: Optional[UUID] = None
+    prompt_template: Optional[str] = None
+    order: Optional[int] = None
 
 
-class ArticleGroupOut(BaseModel):
+class ArticleGroupOut(ArticleGroupIn):
     id: UUID
-    name: str
-    description: Optional[str]
 
     class Config:
         orm_mode = True
+
+
+class ArticleGroupTreeNode(ArticleGroupOut):
+    children: List["ArticleGroupTreeNode"] = []
+    articles: List["ArticleOut"] = []
+
+
+class ArticleWithGroup(ArticleOut):
+    group: Optional[ArticleGroupOut] = None
 
 
 class UserCreate(BaseModel):
@@ -117,3 +129,7 @@ class RegisterResponse(BaseModel):
     team_id: UUID
     access_token: str
     refresh_token: str
+
+
+ArticleGroupTreeNode.update_forward_refs()
+ArticleWithGroup.update_forward_refs()


### PR DESCRIPTION
## Summary
- add parent-child hierarchy, prompts, and ordering for article groups
- expose CRUD and tree endpoints for article groups and allow assigning articles to groups
- filter search by group and show group tree / selectors in Streamlit UI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894ba3b4e6883329ded027b71cd46f2