### PR TITLE
Fix Streamlit rerun call for new API

### DIFF
--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -191,7 +191,10 @@ def render_sidebar_tree() -> None:
                             st.session_state.view_article = None
                             st.session_state.view_history = None
                         st.session_state.page = "Статья по ID"
-                        st.experimental_rerun()
+                        if hasattr(st, "rerun"):
+                            st.rerun()
+                        else:  # pragma: no cover - for older Streamlit versions
+                            st.experimental_rerun()
                 show(node.get("children", []))
 
     show(tree)


### PR DESCRIPTION
## Summary
- handle deprecated `st.experimental_rerun`
- use `st.rerun` with fallback for older Streamlit

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689508d694d48332af6993f77938bdea