### PR TITLE
Use Quill editor on edit article page

### DIFF
--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -565,7 +565,15 @@ elif page == "Редактировать статью":
         format_func=lambda x: x[1],
         key="edit_group",
     )
-    markdown_editor("Новый текст статьи", key="edit_content", height=300)
+    content = st_quill(
+        value=_state_str("edit_content"),
+        html=True,
+        placeholder="Напишите статью...",
+        key="edit_content_editor",
+    )
+
+    if content is not None:
+        st.session_state["edit_content"] = content
 
     col1, col2 = st.columns([1, 1])
     with col1:


### PR DESCRIPTION
## Summary
- Replace edit article page's markdown editor with the Quill editor used on create article page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68950b5006988332a94f6a70fcd565f4