### PR TITLE
Add link to edit article from view page

### DIFF
--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -604,6 +604,9 @@ elif page == "Редактировать статью":
         "Article ID", key="edit_article_id", on_change=_load_edit_article
     )
 
+    # If article ID was preset (e.g. from another page), load it automatically
+    _load_edit_article()
+
     title = st.text_input("Новый заголовок", key="edit_title")
     tags = st.text_input("Новые теги (через запятую)", key="edit_tags")
     st.selectbox(
@@ -718,6 +721,12 @@ elif page == "Статья по ID":
             st.subheader(article["title"])
             st.write(article["content"])
             st.caption(f"Теги: {', '.join(article.get('tags', []))}")
+            if "author" in roles or "admin" in roles:
+                if st.button("Редактировать"):
+                    st.session_state.edit_article_id = article["id"]
+                    st.session_state.pop("edit_loaded_id", None)
+                    st.session_state.page = "Редактировать статью"
+                    st.rerun()
             if st.button("Удалить статью"):
                 try:
                     delete_article(article["id"])


### PR DESCRIPTION
## Summary
- add edit button on "Article by ID" page to open article in editor
- auto-load article in editor when article ID prefilled

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68999286d9fc8332bde4dc98abbfabd5