### PR TITLE
Render formatted HTML for article view and search

### DIFF
--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -817,7 +817,7 @@ elif page == "Поиск":
             for hit in results:
                 st.write(f"**{hit['title']}** · score={hit.get('score'):.3f}")
                 st.caption(f"{hit['id']} · теги: {', '.join(hit.get('tags', []))}")
-                st.write(hit["content"])
+                st.markdown(hit["content"], unsafe_allow_html=True)
                 st.markdown("---")
         except Exception as e:
             st.error(str(e))
@@ -840,7 +840,7 @@ elif page == "Статья по ID":
         tabs = st.tabs(["Статья", "История"])
         with tabs[0]:
             st.subheader(article["title"])
-            st.write(article["content"])
+            st.markdown(article["content"], unsafe_allow_html=True)
             st.caption(f"Теги: {', '.join(article.get('tags', []))}")
             if "author" in roles or "admin" in roles:
                 if st.button("Редактировать"):


### PR DESCRIPTION
## Summary
- Render HTML content with formatting in search results
- Render HTML content with formatting when viewing article by ID

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899ca5330d8833284c48f0cfd7c1095