### PR TITLE
Use group-specific prompt for YandexGPT reranking

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -612,9 +612,13 @@ def search_articles(
     if query.tags:
         required = set(query.tags)
         hits = [h for h in hits if required.issubset(set(h.tags))]
+    group_prompt = None
     if query.group_id:
         hits = [h for h in hits if h.group_id == query.group_id]
-    hits = rerank_with_llm(query.q, hits)
+        group = db.query(ArticleGroup).filter(ArticleGroup.id == query.group_id).first()
+        if group and group.prompt_template:
+            group_prompt = group.prompt_template
+    hits = rerank_with_llm(query.q, hits, prompt_template=group_prompt)
     return hits
 
 

--- a/tests/test_search_prompt.py
+++ b/tests/test_search_prompt.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import types
+import pathlib
+import importlib
+import pytest
+from fastapi.testclient import TestClient
+
+# Configure environment and stub external dependencies before importing app
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+base_dir = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(base_dir))
+sys.path.append(str(base_dir / "backend"))
+
+captured = {}
+fake_qdrant = types.ModuleType("qdrant_utils")
+fake_qdrant.embed_text = lambda text: [0.0] * 256
+fake_qdrant.ensure_collection = lambda: None
+fake_qdrant.insert_vector = lambda *a, **kw: None
+fake_qdrant.delete_vector = lambda *a, **kw: None
+fake_qdrant.search_vector = lambda vector, db, team_id, limit=5: []
+
+def _rerank_with_llm(query, hits, prompt_template=None):
+    captured["prompt_template"] = prompt_template
+    return hits
+
+fake_qdrant.rerank_with_llm = _rerank_with_llm
+sys.modules["qdrant_utils"] = fake_qdrant
+
+import backend.main as main
+importlib.reload(main)
+from backend.main import app, Base, engine
+from backend.auth import init_roles
+
+# Reset database and roles
+Base.metadata.drop_all(bind=engine)
+Base.metadata.create_all(bind=engine)
+init_roles()
+
+client = TestClient(app)
+
+
+def auth_headers(token: str):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def register(email: str):
+    r = client.post("/auth/register", json={"email": email, "password": "password123"})
+    assert r.status_code == 200
+    return r.json()
+
+
+def test_search_uses_group_prompt():
+    user = register("prompt@example.com")
+    token = user["access_token"]
+
+    r = client.post(
+        "/articles/",
+        json={
+            "title": "Title",
+            "content": "Content",
+            "tags": [],
+            "group": {"name": "G1", "prompt_template": "Custom"},
+        },
+        headers=auth_headers(token),
+    )
+    assert r.status_code == 200
+    group_id = r.json()["group_id"]
+
+    r = client.post(
+        "/articles/search/",
+        json={"q": "Title", "group_id": group_id},
+        headers=auth_headers(token),
+    )
+    assert r.status_code == 200
+    assert captured.get("prompt_template") == "Custom"


### PR DESCRIPTION
## Summary
- allow article search reranking to use a group-specific prompt when available
- fetch group prompt in search endpoint and pass to the reranker
- add test ensuring search uses the group's prompt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899cc71125083328d54bd93fe9f9fbf