### PR TITLE
Ensure article content is sent with custom YandexGPT prompts

### DIFF
--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -347,6 +347,13 @@ def llm_recommendations(
             )
         except Exception:
             prompt = prompt_template
+
+        if "{title}" not in prompt_template:
+            prompt = f"Заголовок: {title}\n\n" + prompt
+        if "{content}" not in prompt_template:
+            prompt += f"\n\nТекст статьи:\n{content}"
+        if "{group_articles}" not in prompt_template and articles_info:
+            prompt += articles_info
     else:
         prompt = (
             "Ты – редактор и техписатель. Дай практичные рекомендации по улучшению статьи: "


### PR DESCRIPTION
## Summary
- ensure `llm_recommendations` adds title, article text and group list when custom prompt templates omit placeholders

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899e5e1042c833288cd8a42287b14cb