### PR TITLE
Use API key auth for Yandex embeddings

### DIFF
--- a/backend/qdrant_utils.py
+++ b/backend/qdrant_utils.py
@@ -26,7 +26,7 @@ VECTOR_SIZE = 256
 def get_yandex_embedding(text: str, token: str, folder_id: str) -> list[float]:
     url = YANDEX_API_URL
     headers = {
-        "Authorization": f"Bearer {token}",
+        "Authorization": f"Api-Key {token}",
         "Content-Type": "application/json"
     }
     payload = {
@@ -131,7 +131,7 @@ def rerank_with_llm(
 
     url = "https://llm.api.cloud.yandex.net/foundationModels/v1/completion"
     headers = {
-        "Authorization": f"Bearer {YANDEX_OAUTH_TOKEN}",
+        "Authorization": f"Api-Key {YANDEX_OAUTH_TOKEN}",
         "Content-Type": "application/json",
     }
 
@@ -175,7 +175,7 @@ def rerank_with_llm(
 
 def embed_text(text: str) -> list[float]:
     headers = {
-        "Authorization": f"Bearer {YANDEX_OAUTH_TOKEN}",
+        "Authorization": f"Api-Key {YANDEX_OAUTH_TOKEN}",
         "Content-Type": "application/json"
     }
     payload = {

--- a/tests/test_qdrant_auth.py
+++ b/tests/test_qdrant_auth.py
@@ -1,0 +1,37 @@
+import importlib
+import pathlib
+import sys
+
+
+def test_embed_text_adds_api_key_header(monkeypatch):
+    token = "test-token"
+    folder = "folder-id"
+    monkeypatch.setenv("YANDEX_OAUTH_TOKEN", token)
+    monkeypatch.setenv("YANDEX_FOLDER_ID", folder)
+
+    base_dir = pathlib.Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(base_dir / "backend"))
+    monkeypatch.syspath_prepend(str(base_dir))
+    monkeypatch.delitem(sys.modules, "qdrant_utils", raising=False)
+
+    qdrant_utils = importlib.import_module("qdrant_utils")
+    importlib.reload(qdrant_utils)
+
+    captured = {}
+
+    class DummyResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"embedding": [0.0]}
+
+    def fake_post(url, headers=None, json=None):
+        captured["headers"] = headers
+        return DummyResp()
+
+    monkeypatch.setattr(qdrant_utils.requests, "post", fake_post)
+
+    qdrant_utils.embed_text("hello")
+
+    assert captured["headers"]["Authorization"] == f"Api-Key {token}"


### PR DESCRIPTION
## Summary
- send Yandex API key with `Api-Key` authorization header in embedding and reranking requests
- add tests ensuring the API key header is included

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a41c8c89c8332914cdb31cb82c84c