### PR TITLE
feat: add local embedding fallback

### DIFF
--- a/tests/test_qdrant_auth.py
+++ b/tests/test_qdrant_auth.py
@@ -26,7 +26,7 @@ def test_embed_text_adds_api_key_header(monkeypatch):
         def json(self):
             return {"embedding": [0.0]}
 
-    def fake_post(url, headers=None, json=None):
+    def fake_post(url, headers=None, json=None, **kwargs):
         captured["headers"] = headers
         return DummyResp()
 
@@ -35,3 +35,27 @@ def test_embed_text_adds_api_key_header(monkeypatch):
     qdrant_utils.embed_text("hello")
 
     assert captured["headers"]["Authorization"] == f"Api-Key {token}"
+
+
+def test_embed_text_without_credentials(monkeypatch):
+    base_dir = pathlib.Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(base_dir / "backend"))
+    monkeypatch.syspath_prepend(str(base_dir))
+    monkeypatch.delenv("YANDEX_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("YANDEX_FOLDER_ID", raising=False)
+    monkeypatch.delitem(sys.modules, "qdrant_utils", raising=False)
+
+    qdrant_utils = importlib.import_module("qdrant_utils")
+    importlib.reload(qdrant_utils)
+
+    called = {}
+
+    def fake_post(*args, **kwargs):
+        called["called"] = True
+        raise AssertionError("external request should not be used")
+
+    monkeypatch.setattr(qdrant_utils.requests, "post", fake_post)
+
+    vec = qdrant_utils.embed_text("local text")
+    assert len(vec) == qdrant_utils.VECTOR_SIZE
+    assert "called" not in called


### PR DESCRIPTION
## Summary
- avoid Yandex API dependency by hashing-based local embeddings
- cover embedding logic for missing credentials and allow timeout kwarg in tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a47df87d08332baebd81fbed9a647