### PR TITLE
feat: allow per-team YandexGPT model

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -14,6 +14,7 @@ class Team(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = Column(String, nullable=False, unique=True)
     created_at = Column(DateTime, default=datetime.utcnow)
+    llm_model = Column(String, nullable=False, default="yandexgpt-lite")
 
     users = relationship("User", secondary="user_teams", back_populates="teams")
     articles = relationship("Article", back_populates="team")

--- a/backend/qdrant_utils.py
+++ b/backend/qdrant_utils.py
@@ -124,6 +124,7 @@ def rerank_with_llm(
     query: str,
     hits: List[ArticleSearchHit],
     prompt_template: str | None = None,
+    model: str = "yandexgpt-lite",
 ) -> List[ArticleSearchHit]:
     """Re-rank search hits using YandexGPT if credentials are set."""
     if not (YANDEX_OAUTH_TOKEN and YANDEX_FOLDER_ID) or not hits:
@@ -153,7 +154,7 @@ def rerank_with_llm(
         )
 
     payload = {
-        "modelUri": f"gpt://{YANDEX_FOLDER_ID}/yandexgpt-lite/latest",
+        "modelUri": f"gpt://{YANDEX_FOLDER_ID}/{model}/latest",
         "completionOptions": {"stream": False, "temperature": 0.0, "maxTokens": 200},
         "messages": [{"role": "user", "text": prompt}],
     }

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -140,6 +140,7 @@ class TeamCreate(BaseModel):
 class TeamOut(BaseModel):
     id: UUID
     name: str
+    llm_model: str
 
     class Config:
         orm_mode = True
@@ -155,6 +156,10 @@ class TeamUserOut(BaseModel):
 
 class TeamWithUsers(TeamOut):
     users: List[TeamUserOut] = []
+
+
+class TeamModelUpdate(BaseModel):
+    llm_model: str
 
 
 class TeamInviteRequest(BaseModel):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -104,3 +104,22 @@ def test_admin_panel():
         "/auth/login", json={"email": "user@example.com", "password": "NewPass123"}
     )
     assert r.status_code == 200
+
+    # admin can list teams
+    r = client.get("/admin/teams", headers=auth_headers(admin_token))
+    assert r.status_code == 200
+    teams = r.json()
+    assert any(t["id"] == admin["team_id"] for t in teams)
+
+    # update team model
+    r = client.post(
+        f"/admin/teams/{admin['team_id']}/model",
+        json={"llm_model": "yandexgpt"},
+        headers=auth_headers(admin_token),
+    )
+    assert r.status_code == 200
+
+    # verify model updated
+    r = client.get("/admin/teams", headers=auth_headers(admin_token))
+    team = next(t for t in r.json() if t["id"] == admin["team_id"])
+    assert team["llm_model"] == "yandexgpt"

--- a/tests/test_search_prompt.py
+++ b/tests/test_search_prompt.py
@@ -20,8 +20,9 @@ fake_qdrant.insert_vector = lambda *a, **kw: None
 fake_qdrant.delete_vector = lambda *a, **kw: None
 fake_qdrant.search_vector = lambda vector, db, team_id, limit=5: []
 
-def _rerank_with_llm(query, hits, prompt_template=None):
+def _rerank_with_llm(query, hits, prompt_template=None, model=None):
     captured["prompt_template"] = prompt_template
+    captured["model"] = model
     return hits
 
 fake_qdrant.rerank_with_llm = _rerank_with_llm


### PR DESCRIPTION
## Summary
- add llm_model field for teams and admin endpoints to list/update per-team YandexGPT model
- allow search reranking and frontend LLM calls to use team's selected model
- extend admin UI and tests for team model switching

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a4d30270c8332b6394ca5f9af608a