### PR TITLE
Render search answer with formatting

### DIFF
--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -879,7 +879,7 @@ elif page == "Поиск":
             )[:topk]
             if answer:
                 st.subheader("Ответ")
-                st.write(answer)
+                st.markdown(answer, unsafe_allow_html=True)
             st.subheader("Результаты")
             for hit in results:
                 st.markdown(f"**{hit['title']}**")


### PR DESCRIPTION
## Summary
- render search answers using markdown to preserve article formatting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ae264d4f483329a772c71222522a1