### PR TITLE
fix: open article from search navigates to article page

### DIFF
--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -893,8 +893,11 @@ elif page == "Поиск":
                     st.session_state.view_id = hit["id"]
                     st.session_state.view_article = get_article(hit["id"])
                     st.session_state.view_history = get_history(hit["id"])
-                    st.session_state.pending_page = "Статья по ID"
-                    st.rerun()
+                    st.session_state.page = "Статья по ID"
+                    if hasattr(st, "rerun"):
+                        st.rerun()
+                    else:  # pragma: no cover - for older Streamlit versions
+                        st.experimental_rerun()
                 st.markdown("---")
         except Exception as e:
             st.error(str(e))


### PR DESCRIPTION
## Summary
- ensure "Открыть статью" button on search results switches to article view

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ae475b91c8332bb97720887233c4b