### PR TITLE
feat: add search answer endpoint with LLM summary

### DIFF
--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -51,6 +51,17 @@ class ArticleSearchQuery(BaseModel):
     group_id: Optional[UUID] = None
 
 
+class SearchAnswerRequest(ArticleSearchQuery):
+    top_k: int = 5
+
+
+class SearchAnswerResponse(BaseModel):
+    answer: str
+    sources: List[ArticleSearchHit]
+    prompt_used: str
+    used_group_id: Optional[UUID] = None
+
+
 class ArticleGroupIn(BaseModel):
     name: str
     description: Optional[str] = None


### PR DESCRIPTION
## Summary
- add SearchAnswerRequest and SearchAnswerResponse DTOs
- implement /articles/search/answer endpoint that reranks results and generates an LLM summary

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b1cd266b88332b622c6d8d0b650c8