### PR TITLE
Return search answers without sources list

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -806,10 +806,7 @@ def search_answer(
 
     parts = [f"[{h.title}](wiki://{h.id})\n{h.content}" for h in snippets]
     context = "\n\n".join(parts)
-    base_prompt = (
-        "Сделай краткое резюме ответа на запрос, опираясь только на выдержки. "
-        "В конце дай список источников в формате [Заголовок](wiki://{id})."
-    )
+    base_prompt = "Сделай краткое резюме ответа на запрос, опираясь только на выдержки."
     prompt = f"{base_prompt}\n\nЗапрос: {req.q}\n\n{context}" if context else base_prompt
 
     answer = ""
@@ -837,10 +834,9 @@ def search_answer(
         except Exception as e:
             logger.warning("LLM summary failed: %s", e)
 
-    logger.info("search_answer q=%s sources=%s", req.q, [h.id for h in snippets])
+    logger.info("search_answer q=%s snippets=%s", req.q, [h.id for h in snippets])
     return SearchAnswerResponse(
         answer=answer,
-        sources=snippets,
         prompt_used=prompt,
         used_group_id=req.group_id,
     )

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -67,7 +67,6 @@ class SearchAnswerRequest(ArticleSearchQuery):
 
 class SearchAnswerResponse(BaseModel):
     answer: str
-    sources: List[ArticleSearchHit]
     prompt_used: str
     used_group_id: Optional[UUID] = None
 

--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -898,17 +898,11 @@ elif page == "Поиск":
             group_id = selected_group[0]
 
         answer = ""
-        sources: list[dict] = []
         try:
             data = search_answer(q.strip(), tag_list, group_id, topk)
             answer = data.get("answer", "")
-            sources = sorted(
-                data.get("sources", []),
-                key=lambda h: h.get("score", 0),
-                reverse=True,
-            )[:topk]
         except Exception as e:
-            st.warning(f"Не удалось получить резюме: {e}")
+            st.warning(f"Не удалось получить ответ: {e}")
 
         results: list[dict] = []
         try:
@@ -922,18 +916,8 @@ elif page == "Поиск":
             st.error(str(e))
 
         if answer:
-            st.subheader("Краткое резюме")
+            st.subheader("Ответ")
             st.markdown(answer, unsafe_allow_html=True)
-        if sources:
-            st.subheader("Источники")
-            for hit in sources:
-                st.markdown(f"**{hit['title']}**")
-                st.caption(
-                    f"ID: {hit['id']} · теги: {', '.join(hit.get('tags', []))}"
-                )
-                if st.button("Открыть статью", key=f"src_{hit['id']}"):
-                    open_article(hit["id"])
-                st.markdown("---")
         if results:
             st.subheader("Результаты поиска")
             for hit in results:

--- a/tests/test_search_answer_endpoint.py
+++ b/tests/test_search_answer_endpoint.py
@@ -80,7 +80,7 @@ def register(client: TestClient, email: str):
     return r.json()
 
 
-def test_search_answer_returns_sources(client: TestClient):
+def test_search_answer_returns_answer_without_sources(client: TestClient):
     user = register(client, "ans@example.com")
     token = user["access_token"]
 
@@ -91,7 +91,9 @@ def test_search_answer_returns_sources(client: TestClient):
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["prompt_used"].startswith("Сделай краткое резюме")
-    assert len(data["sources"]) == 2
-    assert data["sources"][0]["title"] == "T1"
+    assert data["prompt_used"].startswith(
+        "Сделай краткое резюме ответа на запрос, опираясь только на выдержки"
+    )
+    assert "answer" in data
+    assert "sources" not in data
 


### PR DESCRIPTION
## Summary
- Remove source list from search answers and adjust API schema
- Update backend prompt and response to only return generated answer
- Simplify frontend search page to show answer instead of sources
- Adjust tests for new search answer behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b8a4064c08332983d7347c4d1fb11