### PR TITLE
Add base prompt editing in admin panel

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -5,6 +5,11 @@ from sqlalchemy.orm import relationship
 from datetime import datetime
 import uuid
 
+
+DEFAULT_BASE_PROMPT = (
+    "Сделай краткое резюме ответа на запрос, опираясь только на выдержки."
+)
+
 Base = declarative_base()
 
 
@@ -15,6 +20,7 @@ class Team(Base):
     name = Column(String, nullable=False, unique=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     llm_model = Column(String, nullable=False, default="yandexgpt-lite")
+    base_prompt = Column(Text, nullable=False, default=DEFAULT_BASE_PROMPT)
 
     users = relationship("User", secondary="user_teams", back_populates="teams")
     articles = relationship("Article", back_populates="team")

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -161,6 +161,7 @@ class TeamOut(BaseModel):
     id: UUID
     name: str
     llm_model: str
+    base_prompt: str
 
     class Config:
         orm_mode = True
@@ -180,6 +181,10 @@ class TeamWithUsers(TeamOut):
 
 class TeamModelUpdate(BaseModel):
     llm_model: str
+
+
+class TeamPromptUpdate(BaseModel):
+    base_prompt: str
 
 
 class TeamInviteRequest(BaseModel):

--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -224,6 +224,12 @@ def admin_update_team_model(team_id: str, llm_model: str):
     return api_post(f"/admin/teams/{team_id}/model", {"llm_model": llm_model})
 
 
+def admin_update_team_prompt(team_id: str, base_prompt: str):
+    return api_post(
+        f"/admin/teams/{team_id}/prompt", {"base_prompt": base_prompt}
+    )
+
+
 def list_my_teams():
     return api_get("/teams/")
 
@@ -1216,9 +1222,15 @@ elif page == "Панель администратора":
                 key=f"team_model_{t['id']}",
                 label_visibility="collapsed",
             )
+            prompt_val = st.text_area(
+                "Базовый промпт",
+                value=t.get("base_prompt", ""),
+                key=f"team_prompt_{t['id']}",
+            )
             if c3.button("Сохранить", key=f"team_save_{t['id']}"):
                 try:
                     admin_update_team_model(t["id"], model_sel)
+                    admin_update_team_prompt(t["id"], prompt_val)
                     st.success("Обновлено")
                     st.rerun()
                 except Exception as e:


### PR DESCRIPTION
## Summary
- Store a customizable `base_prompt` for each team
- Allow admins to update a team's base prompt via API and Streamlit UI
- Use team-specific base prompts when generating search answers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b9fa0e43c8332a4ee3974023b273d