### PR TITLE
Add references to search answers and align tests

### DIFF
--- a/tests/test_search_answer_endpoint.py
+++ b/tests/test_search_answer_endpoint.py
@@ -92,8 +92,9 @@ def test_search_answer_returns_answer_without_sources(client: TestClient):
     assert r.status_code == 200
     data = r.json()
     assert data["prompt_used"].startswith(
-        "Сделай краткое резюме ответа на запрос, опираясь только на выдержки"
+        "Сформулируй единый и связный ответ на запрос пользователя"
     )
-    assert data["answer"]
+    assert "Ссылки на статьи" in data["answer"]
+    assert "- [T1](wiki://1)" in data["answer"]
     assert "sources" not in data
 


### PR DESCRIPTION
## Summary
- update the search answer endpoint to produce a cohesive summary and append links to the underlying articles
- adjust the search answer prompt so the LLM focuses on building a unified response from excerpts
- refresh the search answer test to expect the new prompt and the presence of article links in the answer

## Testing
- pytest tests/test_search_answer_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68cf306c0fb4833290025c8e6b726da6